### PR TITLE
fix: 🐛 exclude .teamcity directory

### DIFF
--- a/lib/services/project.service.ts
+++ b/lib/services/project.service.ts
@@ -57,7 +57,8 @@ function findPackageJsonFiles() {
 function findPomXmlFiles() {
   return findFiles(
     'pom.xml',
-    undefined
+    '',
+    '.teamcity'
     // TODO what to exclude in java repo?
   );
 }


### PR DESCRIPTION
Do not look for pom.xml in the .teamcity directory when checking if the
project type is maven or npm