### PR TITLE
fix: support basename-only JSON paths

### DIFF
--- a/lib/services/fs.service.spec.ts
+++ b/lib/services/fs.service.spec.ts
@@ -1,0 +1,30 @@
+import * as fs from 'fs';
+import { tmpdir } from 'os';
+import * as p from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { writeJson } from './fs.service';
+
+const originalWorkingDirectory = process.cwd();
+let testDirectory: string | undefined;
+
+afterEach(() => {
+  process.chdir(originalWorkingDirectory);
+  if (testDirectory) {
+    fs.rmSync(testDirectory, { recursive: true, force: true });
+    testDirectory = undefined;
+  }
+});
+
+describe('writeJson', () => {
+  it('writes a basename-only path in the current directory', () => {
+    testDirectory = fs.mkdtempSync(p.join(tmpdir(), 'omniboard-analyzer-'));
+    process.chdir(testDirectory);
+
+    writeJson('job.json', { queue: [] });
+
+    expect(JSON.parse(fs.readFileSync('job.json', 'utf8'))).toEqual({
+      queue: [],
+    });
+  });
+});

--- a/lib/services/fs.service.ts
+++ b/lib/services/fs.service.ts
@@ -81,9 +81,11 @@ export function readXmlAsDom(
 }
 
 export function writeJson(destinationPath: string, data: any) {
-  const { base, dir } = p.parse(destinationPath);
+  const { dir } = p.parse(destinationPath);
   const dataAsString = JSON.stringify(data, null, 2);
-  fs.mkdirSync(dir, { recursive: true });
+  if (dir) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
   fs.writeFileSync(destinationPath, dataAsString);
 }
 


### PR DESCRIPTION
## Summary

- avoid calling `mkdirSync` with an empty parent path
- support batch job files such as `job.json` in the current working directory
- cover the regression with a filesystem service test

## Verification

- `npm test` (14 passing)
- `npm run build`
- Prettier check