### PR TITLE
fix: skip upload for excluded projects

### DIFF
--- a/lib/tasks/save-project-api.task.spec.ts
+++ b/lib/tasks/save-project-api.task.spec.ts
@@ -70,6 +70,15 @@ describe('saveProjectApiTask', () => {
     vi.mocked(api.uploadProject).mockReset().mockResolvedValue(undefined);
   });
 
+  it('does not upload a project excluded by an earlier task', async () => {
+    const ctx = createContext(false);
+    ctx.control.skipEverySubsequentTask = true;
+
+    await runSaveTask(ctx);
+
+    expect(api.uploadProject).not.toHaveBeenCalled();
+  });
+
   it('aborts before upload with exact size details by default', async () => {
     const ctx = createContext(false);
 

--- a/lib/tasks/save-project-api.task.ts
+++ b/lib/tasks/save-project-api.task.ts
@@ -53,6 +53,10 @@ export const saveProjectApiTask: ListrTask = {
     }
   },
   task: async (ctx, task) => {
+    if (ctx.control.skipEverySubsequentTask) {
+      return;
+    }
+
     const { results, rejectedCheckResults } = prepareProjectResultsForUpload(
       ctx.results,
       ctx.settings


### PR DESCRIPTION
## Summary

- re-check the project exclusion flag when the upload task executes
- prevent blocklisted projects from reaching the API even when Listr evaluated `skip` before project resolution
- allow batch finalization to classify intentional exclusions as completed rather than failed

## Root cause

Project-name resolution marks blocklisted projects with `skipEverySubsequentTask`. The upload task relied only on its Listr `skip` callback, which can be evaluated before that earlier task sets the flag in batch execution. The task then uploaded the excluded project, and the API rejection rolled the repository into `failed`.

## Verification

- focused upload-task regression test
- `npm test` (15 passing)
- `npm run build`
- Prettier check

Related: UXF-3626